### PR TITLE
Fix the syntax error in getTypeOptions method

### DIFF
--- a/models/Directive.php
+++ b/models/Directive.php
@@ -46,7 +46,7 @@ class Directive extends Model
     public function getTypeOptions($fieldName = null, $keyValue = null)
     {
         return ['Allow'     => 'Allow',
-                'Disallow'  => 'Disallow'
+                'Disallow'  => 'Disallow',
                 'Host'      => 'Host',
                 'Sitemap'   => 'Sitemap'];
     }


### PR DESCRIPTION
In the method getTypeOptions the array is broken, it's missing one comma.
